### PR TITLE
Merge pull request #17 from aaronpeikert:feature/unquote

### DIFF
--- a/src/syntax/symbol.jl
+++ b/src/syntax/symbol.jl
@@ -11,6 +11,7 @@ function quote_symbols(ex::Expr)
 
     if ex.head == :call
         if ex.args[1] == :_ 
+            length(ex.args) > 2 ? error("Unqote only a single argument. Right: `_(x)`, Wrong: `_(x, y)`.") : nothing
             return ex.args[2]
         end
         to_quote = to_quote[2:end]

--- a/src/syntax/symbol.jl
+++ b/src/syntax/symbol.jl
@@ -10,6 +10,9 @@ function quote_symbols(ex::Expr)
     to_quote = eachindex(ex.args)
 
     if ex.head == :call
+        if ex.args[1] == :_ 
+            return ex.args[2]
+        end
         to_quote = to_quote[2:end]
     end
     for i in to_quote
@@ -19,5 +22,5 @@ function quote_symbols(ex::Expr)
 end
 
 macro quote_symbols(ex)
-    quote_symbols(ex)
+    esc(quote_symbols(ex))
 end

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -1,5 +1,7 @@
 @testset "Quoted Symbol Syntax" begin
     @test (:a → :b) == (StenoGraphs.@quote_symbols a → b)
+    b = :c
+    @test (:a → :c) == (StenoGraphs.@quote_symbols a → _(b))
 end
 
 @testset "Addition as hcat" begin

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -2,6 +2,15 @@
     @test (:a → :b) == (StenoGraphs.@quote_symbols a → b)
     b = :c
     @test (:a → :c) == (StenoGraphs.@quote_symbols a → _(b))
+    let err = nothing
+        try
+            eval(:(StenoGraphs.@quote_symbols a → _(b, c)))
+        catch err
+        end
+    
+        @test err isa Exception
+        @test  occursin("Unqote only a single argument. Right: `_(x)`, Wrong: `_(x, y)`.", sprint(showerror, err))
+    end
 end
 
 @testset "Addition as hcat" begin


### PR DESCRIPTION
This feature enables a way (`_(...)`) to get around the standard quoting (converting to symbols) of the @StenoGraph macro.