### PR TITLE
add a let version

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+* `@StenoGraph let a, b; ... end` — explicit node declaration in a scoped `let` block. Declared symbols become `SimpleNode`s; all other symbols are normal Julia variables (no `_()` escaping needed). Bindings don't leak into the surrounding namespace.
+* `@StenoGraph let nodes...; ... end` — splat form that exposes all nodes from an existing collection as local variables, using `id()` to extract variable names. Supports multiple collections (`let v1..., v2...`) and mixing with inline declarations (`let a, nodes...`).
+
 ### Changed
 
 * Improved macro hygiene for `@StenoGraph`: replaced wholesale `esc()` with selective escaping. User-provided expressions (function names, literals) are escaped to resolve in caller context, while macro-introduced symbols (`SimpleNode`, `StenoGraph`, `convert_symbol`) remain unescaped and are resolved via Julia's built-in macro hygiene. This fixes re-export scenarios where a downstream package re-exports `@StenoGraph` without the end-user ever loading `StenoGraphs` directly.

--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+* Improved macro hygiene for `@StenoGraph`: replaced wholesale `esc()` with selective escaping. User-provided expressions (function names, literals) are escaped to resolve in caller context, while macro-introduced symbols (`SimpleNode`, `StenoGraph`, `convert_symbol`) remain unescaped and are resolved via Julia's built-in macro hygiene. This fixes re-export scenarios where a downstream package re-exports `@StenoGraph` without the end-user ever loading `StenoGraphs` directly.
+* Function names in call expressions (e.g., user-defined `EdgeModifier` constructors) and broadcast expressions are now explicitly escaped in `variable_as_node!` so they resolve in the caller's scope.
+* `@variable_as_node` no longer wraps its result in `esc()`, consistent with the new selective escaping approach.
+* `addition_to_vector!` is now applied before `variable_as_node!` in `StenoGraph_macro`, so that `+` is converted to `hcat` before symbols are escaped.
+* Used `nameof(node)` instead of `Symbol(node)` in `variable_as_node!` to produce unqualified type names regardless of calling context.
+
+### Fixed
+
+* `@StenoGraph` now works correctly when re-exported by a downstream package: end-users no longer need `StenoGraphs` in their namespace (closes [`#73`](https://github.com/aaronpeikert/StenoGraphs.jl/issues/73)).
+
 ## [0.4.4]
 
 ### Added

--- a/src/id.jl
+++ b/src/id.jl
@@ -14,6 +14,10 @@ julia> id(Node(1))
 
 """
 
+function id(node::Symbol)
+    node
+end
+
 function id(node::AbstractNode)
     keep(node, Node).node
 end

--- a/src/syntax/addition.jl
+++ b/src/syntax/addition.jl
@@ -3,7 +3,7 @@ function addition_to_vector!(ex)
 end
 
 function addition_to_vector!(ex::Expr)
-    if ex.args[1] == :+
+    if ex.head == :call && ex.args[1] == :+
         return Expr(:hcat, ex.args[2:end]...)
     else
         for i in eachindex(ex.args)

--- a/src/syntax/macro.jl
+++ b/src/syntax/macro.jl
@@ -4,7 +4,7 @@ function StenoGraph_macro(ex)
         exs = StenoGraphs.variable_as_node!.(exs)
         exs = StenoGraphs.addition_to_vector!.(exs)
         vec = Expr(:call, :vcat, exs...)
-        return esc(:(StenoGraphs.StenoGraph($vec)))
+        return :(StenoGraph($vec))
     else
         StenoGraph_macro(Expr(:block, ex))
     end

--- a/src/syntax/macro.jl
+++ b/src/syntax/macro.jl
@@ -1,8 +1,8 @@
 function StenoGraph_macro(ex)
     if ex.head == :block
         exs = filter(x -> !isa(x, LineNumberNode), ex.args)
-        exs = StenoGraphs.variable_as_node!.(exs)
         exs = StenoGraphs.addition_to_vector!.(exs)
+        exs = StenoGraphs.variable_as_node!.(exs)
         vec = Expr(:call, :vcat, exs...)
         return :(StenoGraph($vec))
     else

--- a/src/syntax/macro.jl
+++ b/src/syntax/macro.jl
@@ -1,5 +1,7 @@
 function StenoGraph_macro(ex)
-    if ex.head == :block
+    if ex isa Expr && ex.head == :let
+        return StenoGraph_let_macro(ex)
+    elseif ex isa Expr && ex.head == :block
         exs = filter(x -> !isa(x, LineNumberNode), ex.args)
         exs = StenoGraphs.addition_to_vector!.(exs)
         exs = StenoGraphs.variable_as_node!.(exs)
@@ -9,10 +11,114 @@ function StenoGraph_macro(ex)
         StenoGraph_macro(Expr(:block, ex))
     end
 end
+
+# --- let-style @StenoGraph ---
+
+"""
+    _stenograph_let_from(collections, body_expr)
+
+Runtime helper for the splat form of `@StenoGraph let nodes... ...end`.
+Builds a scoped `let` expression from the node collections and evaluates it.
+
+Each node in the collections is exposed as a local variable named by its `id()`.
+For duplicate ids, the last occurrence wins.
+"""
+function _stenograph_let_from(collections, body_expr)
+    bindings = Expr[]
+    for col in collections
+        for node in col
+            push!(bindings, Expr(:(=), id(node), convert(Node, node)))
+        end
+    end
+    let_expr = Expr(:let, Expr(:block, bindings...), body_expr)
+    Base.invokelatest(eval, let_expr)
+end
+
+"""
+    StenoGraph_let_macro(ex)
+
+Handle `@StenoGraph let ... end` forms. Dispatches between:
+- **Inline**: `@StenoGraph let a, b; ... end` — symbols become fresh `SimpleNode`s
+- **Splat**: `@StenoGraph let nodes...; ... end` — nodes from collection(s) exposed as variables
+- **Mixed**: `@StenoGraph let a, nodes...; ... end` — combination of both
+"""
+function StenoGraph_let_macro(ex)
+    bindings_ast = ex.args[1]
+    body = ex.args[2]
+
+    # Parse bindings into bare symbols and splat expressions
+    bare_syms, splat_exprs = _parse_let_bindings(bindings_ast)
+
+    # Transform body: apply addition_to_vector! but NOT variable_as_node!
+    body_exprs = filter(x -> !isa(x, LineNumberNode), body.args)
+    body_exprs = StenoGraphs.addition_to_vector!.(body_exprs)
+
+    if isempty(splat_exprs)
+        # Pure inline form: generate a compile-time let expression
+        # StenoGraph and vcat resolve from the macro's module via hygiene;
+        # body expressions are esc'd to resolve in the caller's scope.
+        vec = Expr(:call, :vcat, esc.(body_exprs)...)
+        graph_body = :(StenoGraph($vec))
+        new_bindings = [Expr(:(=), esc(s), :(SimpleNode($(QuoteNode(s))))) for s in bare_syms]
+        return Expr(:let, Expr(:block, new_bindings...), graph_body)
+    else
+        # Splat form (possibly with bare symbols mixed in):
+        # Build the body expression as a QuoteNode so it can be eval'd at runtime.
+        # Use fully-qualified StenoGraphs.StenoGraph so it resolves at eval time.
+        vec = Expr(:call, :vcat, body_exprs...)
+        splat_body = :(StenoGraphs.StenoGraph($vec))
+        # Bare symbols get prepended as SimpleNode bindings at runtime too
+        bare_collection = if isempty(bare_syms)
+            :([])
+        else
+            Expr(:vcat, [:(SimpleNode($(QuoteNode(s)))) for s in bare_syms]...)
+        end
+        collections = Expr(:vcat, bare_collection, [esc(s) for s in splat_exprs]...)
+        return :(_stenograph_let_from([$collections], $(QuoteNode(splat_body))))
+    end
+end
+
+"""
+    _parse_let_bindings(bindings_ast)
+
+Parse the bindings part of a `let` expression into bare symbols and splat expressions.
+Returns `(bare_syms::Vector{Symbol}, splat_exprs::Vector)`.
+"""
+function _parse_let_bindings(bindings_ast)
+    bare_syms = Symbol[]
+    splat_exprs = Any[]
+
+    if isa(bindings_ast, Symbol)
+        # Single bare symbol: `let a`
+        push!(bare_syms, bindings_ast)
+    elseif isa(bindings_ast, Expr) && bindings_ast.head == Symbol("...")
+        # Single splat: `let nodes...`
+        push!(splat_exprs, bindings_ast.args[1])
+    elseif isa(bindings_ast, Expr) && bindings_ast.head == :block
+        # Multiple bindings: `let a, b, nodes...`
+        for arg in bindings_ast.args
+            if isa(arg, Symbol)
+                push!(bare_syms, arg)
+            elseif isa(arg, Expr) && arg.head == Symbol("...")
+                push!(splat_exprs, arg.args[1])
+            elseif isa(arg, LineNumberNode)
+                continue
+            else
+                error("Invalid binding in @StenoGraph let: $arg")
+            end
+        end
+    else
+        error("Invalid bindings in @StenoGraph let: $bindings_ast")
+    end
+
+    return bare_syms, splat_exprs
+end
 """
     @StenoGraph
 
 The `@StenoGraph` macro allows you to refer to nodes without explicitly declaring them.
+
+## Block form (auto-quoting)
 
 ```jldoctest
 @StenoGraph begin
@@ -29,7 +135,32 @@ The main downside is that you can not use regular variables inside the macro.
 Had you declared `c = [Node(:a) Node(:b)]` outside the macro, inside it would nevertheless refer to `Node(:c)`.
 You would need to escape it using [`_`](@ref), i.e. use it as `_(c)` within the macro.
 
-See also [`@declage_nodes`](@ref) & [`@declage_nodes_from`](@ref) for alternatives to escaping.
+## Let form (explicit declaration)
+
+Alternatively, use a `let` block to explicitly declare which symbols become nodes.
+All other symbols are treated as normal Julia variables — no escaping needed.
+The node bindings are scoped and do not leak into the surrounding namespace.
+
+```julia
+@StenoGraph let a, b, c
+    a → b → c
+end
+```
+
+## Let form with splat (from node collections)
+
+Use `...` to expose all nodes from an existing collection as local variables.
+Node names are extracted via [`id`](@ref). Supports multiple collections and mixing
+with inline declarations.
+
+```julia
+nodes = [Node(:a), Node(:b)]
+@StenoGraph let nodes...
+    a → b
+end
+```
+
+See also [`@declare_nodes`](@ref) & [`@declare_nodes_from`](@ref) for alternatives to escaping.
 
 """
 macro StenoGraph(ex)
@@ -78,7 +209,7 @@ c = Node(:c)
 c
 ```
 
-Please note that if you defined `c` and then use `@declase_nodes c`, `c` will be overwritten!
+Please note that if you defined `c` and then use `@declare_nodes c`, `c` will be overwritten!
 
 For programmatic use see also [`@declare_nodes_from`](@ref).
 """
@@ -117,7 +248,7 @@ e = Node(:e)
 e
 ```
 
-Please note that if you defined `c` and then use `@declare_nodes c`, `c` will be overwritten!
+Please note that if you defined `c` and then use `@declare_nodes vec`, and `vec` contains `c`, `c` will be overwritten!
 
 For non-programatic use see also [`@declare_nodes`](@ref).
 """

--- a/src/syntax/variable_as_node.jl
+++ b/src/syntax/variable_as_node.jl
@@ -3,7 +3,7 @@ function variable_as_node!(ex, node::Type{T} where {T <: AbstractNode})
 end
 
 function variable_as_node!(ex::Symbol, node::Type{T} where {T <: AbstractNode})
-    Expr(:call, Symbol(node), QuoteNode(ex))
+    Expr(:call, nameof(node), QuoteNode(ex))
 end
 
 function variable_as_node!(ex::Expr, node::Type{T} where {T <: AbstractNode})

--- a/src/syntax/variable_as_node.jl
+++ b/src/syntax/variable_as_node.jl
@@ -10,20 +10,23 @@ function variable_as_node!(ex::Expr, node::Type{T} where {T <: AbstractNode})
     to_quote = eachindex(ex.args)
 
     if ex.head == :call
-        if ex.args[1] == :_ 
+        if ex.args[1] == :_
             length(ex.args) > 2 ? error("Unqote only a single argument. Right: `_(x)`, Wrong: `_(x, y)`.") : nothing
-            return Expr(:call, :(StenoGraphs.convert_symbol), ex.args[2], :(StenoGraphs.SimpleNode))
+            return Expr(:call, :convert_symbol, esc(ex.args[2]), :SimpleNode)
         end
+        # Escape function name so it resolves in caller context
+        ex.args[1] = esc(ex.args[1])
         to_quote = to_quote[2:end]
     end
     # For broadcast operators, skip the first argument to prevent the function name from being converted to a node. issue #63
     if ex.head == :.
+        ex.args[1] = esc(ex.args[1])
         to_quote = to_quote[2:end]
     end
     for i in to_quote
         ex.args[i] = variable_as_node!(ex.args[i], node)
     end
-    ex 
+    ex
 end
 
 convert_symbol(x) = x
@@ -34,5 +37,5 @@ convert_symbol(x::VecOrMat{Symbol}, T) = convert.(T, x)
 variable_as_node!(ex) = variable_as_node!(ex, SimpleNode)
 
 macro variable_as_node(ex)
-    esc(variable_as_node!(ex, SimpleNode))
+    variable_as_node!(ex, SimpleNode)
 end

--- a/test/export.jl
+++ b/test/export.jl
@@ -24,4 +24,24 @@
     @test result.graph == [Edge(Node(:a), Node(:b))]
     @test result.addition == [Edge(Node(:a), Node(:c)), Edge(Node(:b), Node(:c))]
     @test result.multiline == [Edge(Node(:a), Node(:b)), Edge(Node(:d), Node(:c))]
+
+    # Let-style forms also work when re-exported
+    result_let = @eval module _EndUserTestLet
+        using ..$(nameof(m)): @StenoGraph, →, ←, ↔
+        using StenoGraphs: Node, Edge
+        graph = @StenoGraph let a, b
+            a → b
+        end
+    end
+    @test result_let.graph == [Edge(Node(:a), Node(:b))]
+
+    result_splat = @eval module _EndUserTestSplat
+        using ..$(nameof(m)): @StenoGraph, →, ←, ↔
+        using StenoGraphs: Node, Edge
+        nodes = [Node(:a), Node(:b)]
+        graph = @StenoGraph let nodes...
+            a → b
+        end
+    end
+    @test result_splat.graph == [Edge(Node(:a), Node(:b))]
 end

--- a/test/export.jl
+++ b/test/export.jl
@@ -1,0 +1,25 @@
+@testset "Re-exported @StenoGraph resolves without StenoGraphs in scope" begin
+    # Simulate a downstream package that re-exports @StenoGraph and arrows.
+    # The macro should work without `SimpleNode`, `StenoGraph`, or
+    # `convert_symbol` being directly available in the end-user's namespace.
+    # https://github.com/aaronpeikert/StenoGraphs.jl/issues/73
+    m = @eval module _ReExportTest
+        using StenoGraphs: @StenoGraph, →, ←, ↔
+        export @StenoGraph, →, ←, ↔
+    end
+    # Use the re-exported macro from an "end-user" context
+    # that has no direct access to StenoGraphs internals.
+    result = @eval module _EndUserTest
+        using ..$(nameof(m)): @StenoGraph, →, ←, ↔
+        using StenoGraphs: Node, Edge
+        graph = @StenoGraph a → b
+        addition = @StenoGraph a + b → c
+        multiline = @StenoGraph begin
+            a → b
+            c ← d
+        end
+    end
+    @test result.graph == [Edge(Node(:a), Node(:b))]
+    @test result.addition == [Edge(Node(:a), Node(:c)), Edge(Node(:b), Node(:c))]
+    @test result.multiline == [Edge(Node(:a), Node(:b)), Edge(Node(:d), Node(:c))]
+end

--- a/test/export.jl
+++ b/test/export.jl
@@ -19,6 +19,8 @@
             c ← d
         end
     end
+    @test_throws UndefVarError StenoGraphs.Edge
+    using StenoGraphs # note results is already constructed without StenoGraphs availible
     @test result.graph == [Edge(Node(:a), Node(:b))]
     @test result.addition == [Edge(Node(:a), Node(:c)), Edge(Node(:b), Node(:c))]
     @test result.multiline == [Edge(Node(:a), Node(:b)), Edge(Node(:d), Node(:c))]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -58,6 +58,11 @@ using Test, SafeTestsets, Documenter
         using StenoGraphs, DataFrames
         include("DataFrames.jl")
     end
+    if VERSION ≥ v"1.12-"
+    @safetestset "Export" begin
+        include("export.jl")
+    end
+    end 
     DocMeta.setdocmeta!(StenoGraphs, :DocTestSetup, :(using StenoGraphs); recursive=true)
     doctest(StenoGraphs)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -59,9 +59,9 @@ using Test, SafeTestsets, Documenter
         include("DataFrames.jl")
     end
     if VERSION ≥ v"1.12-"
-    @safetestset "Export" begin
+        @safetestset "Export" begin
         include("export.jl")
-    end
+        end
     end 
     DocMeta.setdocmeta!(StenoGraphs, :DocTestSetup, :(using StenoGraphs); recursive=true)
     doctest(StenoGraphs)

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -30,35 +30,6 @@ end
     @test [Edge(Node(:a), Node(:c)), Edge(Node(:b), Node(:c))] == @StenoGraph [a b] → c
 end
 
-if VERSION ≥ v"1.12-"
-    @testset "Re-exported @StenoGraph resolves without StenoGraphs in scope" begin
-        # Simulate a downstream package that re-exports @StenoGraph and arrows.
-        # The macro should work without `SimpleNode`, `StenoGraph`, or
-        # `convert_symbol` being directly available in the end-user's namespace.
-        # https://github.com/aaronpeikert/StenoGraphs.jl/issues/73
-        m = @eval module _ReExportTest
-            using StenoGraphs: @StenoGraph, →, ←, ↔
-            export @StenoGraph, →, ←, ↔
-        end
-        # Use the re-exported macro from an "end-user" context
-        # that has no direct access to StenoGraphs internals.
-        result = @eval module _EndUserTest
-            using ..$(nameof(m)): @StenoGraph, →, ←, ↔
-            using StenoGraphs: Node, Edge
-            graph = @StenoGraph a → b
-            addition = @StenoGraph a + b → c
-            multiline = @StenoGraph begin
-                a → b
-                c ← d
-            end
-        end
-        @test result.graph == [Edge(Node(:a), Node(:b))]
-        @test result.addition == [Edge(Node(:a), Node(:c)), Edge(Node(:b), Node(:c))]
-        @test result.multiline == [Edge(Node(:a), Node(:b)), Edge(Node(:d), Node(:c))]
-    end    
-end
-
-
 @testset "Multiline Arrows" begin
     @test [Edge(Node(:a), Node(:c)), Edge(Node(:b), Node(:c)), Edge(Node.(:f), Node.(:e))] == @StenoGraph begin
         [a b] → c

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -30,31 +30,34 @@ end
     @test [Edge(Node(:a), Node(:c)), Edge(Node(:b), Node(:c))] == @StenoGraph [a b] → c
 end
 
-@testset "Re-exported @StenoGraph resolves without StenoGraphs in scope" begin
-    # Simulate a downstream package that re-exports @StenoGraph and arrows.
-    # The macro should work without `SimpleNode`, `StenoGraph`, or
-    # `convert_symbol` being directly available in the end-user's namespace.
-    # https://github.com/aaronpeikert/StenoGraphs.jl/issues/73
-    m = @eval module _ReExportTest
-        using StenoGraphs: @StenoGraph, →, ←, ↔
-        export @StenoGraph, →, ←, ↔
-    end
-    # Use the re-exported macro from an "end-user" context
-    # that has no direct access to StenoGraphs internals.
-    result = @eval module _EndUserTest
-        using ..$(nameof(m)): @StenoGraph, →, ←, ↔
-        using StenoGraphs: Node, Edge
-        graph = @StenoGraph a → b
-        addition = @StenoGraph a + b → c
-        multiline = @StenoGraph begin
-            a → b
-            c ← d
+if VERSION ≥ v"1.12-"
+    @testset "Re-exported @StenoGraph resolves without StenoGraphs in scope" begin
+        # Simulate a downstream package that re-exports @StenoGraph and arrows.
+        # The macro should work without `SimpleNode`, `StenoGraph`, or
+        # `convert_symbol` being directly available in the end-user's namespace.
+        # https://github.com/aaronpeikert/StenoGraphs.jl/issues/73
+        m = @eval module _ReExportTest
+            using StenoGraphs: @StenoGraph, →, ←, ↔
+            export @StenoGraph, →, ←, ↔
         end
-    end
-    @test result.graph == [Edge(Node(:a), Node(:b))]
-    @test result.addition == [Edge(Node(:a), Node(:c)), Edge(Node(:b), Node(:c))]
-    @test result.multiline == [Edge(Node(:a), Node(:b)), Edge(Node(:d), Node(:c))]
+        # Use the re-exported macro from an "end-user" context
+        # that has no direct access to StenoGraphs internals.
+        result = @eval module _EndUserTest
+            using ..$(nameof(m))?: @StenoGraph, →, ←, ↔
+            using StenoGraphs: Node, Edge
+            graph = @StenoGraph a → b
+            addition = @StenoGraph a + b → c
+            multiline = @StenoGraph begin
+                a → b
+                c ← d
+            end
+        end
+        @test result.graph == [Edge(Node(:a), Node(:b))]
+        @test result.addition == [Edge(Node(:a), Node(:c)), Edge(Node(:b), Node(:c))]
+        @test result.multiline == [Edge(Node(:a), Node(:b)), Edge(Node(:d), Node(:c))]
+    end    
 end
+
 
 @testset "Multiline Arrows" begin
     @test [Edge(Node(:a), Node(:c)), Edge(Node(:b), Node(:c)), Edge(Node.(:f), Node.(:e))] == @StenoGraph begin

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -62,6 +62,102 @@ end
     @test StenoGraphs.variable_as_node!(:(fun(a))) == Expr(:call, Expr(:escape, :fun), :(SimpleNode(:a)))
 end
 
+@testset "Let-style @StenoGraph (inline)" begin
+    # Basic
+    @test @StenoGraph(let a, b; a → b; end) == [Edge(Node(:a), Node(:b))]
+
+    # Chain arrows
+    @test @StenoGraph(let a, b, c; a → b → c; end) ==
+        [Edge(Node(:a), Node(:b)), Edge(Node(:b), Node(:c))]
+
+    # Addition syntax (+ → hcat)
+    @test @StenoGraph(let a, b, c; a + b → c; end) ==
+        [Edge(Node(:a), Node(:c)), Edge(Node(:b), Node(:c))]
+
+    # Multiline block
+    @test @StenoGraph(let a, b, c, d
+        a → b
+        c → d
+    end) == [Edge(Node(:a), Node(:b)), Edge(Node(:c), Node(:d))]
+
+    # Scoping: variables don't leak
+    @StenoGraph let _let_scope_a, _let_scope_b
+        _let_scope_a → _let_scope_b
+    end
+    @test !@isdefined(_let_scope_a)
+    @test !@isdefined(_let_scope_b)
+
+    # External variables work without _() escape
+    let ext = Node(:ext)
+        @test @StenoGraph(let a; a → ext; end) ==
+            [Edge(Node(:a), Node(:ext))]
+    end
+
+    # Arrow directions
+    @test @StenoGraph(let a, b; a ← b; end) == [Edge(Node(:b), Node(:a))]
+    @test @StenoGraph(let a, b; a ↔ b; end) == [UndirectedEdge(Node(:a), Node(:b))]
+end
+
+@testset "Let-style @StenoGraph (splat from collection)" begin
+    # Basic splat
+    nodes = [Node(:a), Node(:b)]
+    @test @StenoGraph(let nodes...; a → b; end) == [Edge(Node(:a), Node(:b))]
+
+    # Addition syntax
+    nodes = [Node(:a), Node(:b), Node(:c)]
+    @test @StenoGraph(let nodes...; a + b → c; end) ==
+        [Edge(Node(:a), Node(:c)), Edge(Node(:b), Node(:c))]
+
+    # Multiline
+    nodes = [Node(:a), Node(:b), Node(:c)]
+    @test @StenoGraph(let nodes...
+        a → b
+        b → c
+    end) == [Edge(Node(:a), Node(:b)), Edge(Node(:b), Node(:c))]
+
+    # Preserves ModifiedNode
+    struct _TestLabelSplat <: NodeModifier; l::String; end
+    mod_nodes = [ModifiedNode(Node(:a), _TestLabelSplat("A")), Node(:b)]
+    result = @StenoGraph let mod_nodes...
+        a → b
+    end
+    @test result[1].src isa ModifiedNode
+
+    # Duplicate ids: last wins
+    dup_nodes = [Node(:a), ModifiedNode(Node(:a), _TestLabelSplat("A2")), Node(:b)]
+    result = @StenoGraph let dup_nodes...
+        a → b
+    end
+    @test result[1].src isa ModifiedNode
+
+    # Symbol vector (like declare_nodes_from)
+    syms = [:x, :y]
+    @test @StenoGraph(let syms...; x → y; end) == [Edge(Node(:x), Node(:y))]
+
+    # Multiple splats
+    nodes1 = [Node(:a), Node(:b)]
+    nodes2 = [Node(:c), Node(:d)]
+    @test @StenoGraph(let nodes1..., nodes2...
+        a → c
+        b → d
+    end) == [Edge(Node(:a), Node(:c)), Edge(Node(:b), Node(:d))]
+
+    # Mixed bare symbols + splat
+    nodes = [Node(:c), Node(:d)]
+    @test @StenoGraph(let a, b, nodes...
+        a → c
+        b → d
+    end) == [Edge(Node(:a), Node(:c)), Edge(Node(:b), Node(:d))]
+
+    # Scoping: variables don't leak
+    _splat_scope_nodes = [Node(:_splat_scope_a), Node(:_splat_scope_b)]
+    @StenoGraph let _splat_scope_nodes...
+        _splat_scope_a → _splat_scope_b
+    end
+    @test !@isdefined(_splat_scope_a)
+    @test !@isdefined(_splat_scope_b)
+end
+
 @testset "Macro hygiene: SimpleNode resolved via Julia hygiene, not module-qualification" begin
     # variable_as_node! produces bare SimpleNode (not StenoGraphs.SimpleNode).
     # Julia's macro hygiene resolves it from the defining module.

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -30,6 +30,32 @@ end
     @test [Edge(Node(:a), Node(:c)), Edge(Node(:b), Node(:c))] == @StenoGraph [a b] → c
 end
 
+@testset "Re-exported @StenoGraph resolves without StenoGraphs in scope" begin
+    # Simulate a downstream package that re-exports @StenoGraph and arrows.
+    # The macro should work without `SimpleNode`, `StenoGraph`, or
+    # `convert_symbol` being directly available in the end-user's namespace.
+    # https://github.com/aaronpeikert/StenoGraphs.jl/issues/73
+    m = @eval module _ReExportTest
+        using StenoGraphs: @StenoGraph, →, ←, ↔
+        export @StenoGraph, →, ←, ↔
+    end
+    # Use the re-exported macro from an "end-user" context
+    # that has no direct access to StenoGraphs internals.
+    result = @eval module _EndUserTest
+        using ..$(nameof(m)): @StenoGraph, →, ←, ↔
+        using StenoGraphs: Node, Edge
+        graph = @StenoGraph a → b
+        addition = @StenoGraph a + b → c
+        multiline = @StenoGraph begin
+            a → b
+            c ← d
+        end
+    end
+    @test result.graph == [Edge(Node(:a), Node(:b))]
+    @test result.addition == [Edge(Node(:a), Node(:c)), Edge(Node(:b), Node(:c))]
+    @test result.multiline == [Edge(Node(:a), Node(:b)), Edge(Node(:d), Node(:c))]
+end
+
 @testset "Multiline Arrows" begin
     @test [Edge(Node(:a), Node(:c)), Edge(Node(:b), Node(:c)), Edge(Node.(:f), Node.(:e))] == @StenoGraph begin
         [a b] → c
@@ -72,5 +98,7 @@ end
     ex = StenoGraphs.variable_as_node!(:(MyFunc(a)))
     @test ex.args[1] == Expr(:escape, :MyFunc)
     @test ex.args[2] == Expr(:call, :SimpleNode, QuoteNode(:a))
-    @test @macroexpand(StenoGraphs.@variable_as_node a) == :(StenoGraphs.SimpleNode(:a))
+    expanded = @macroexpand(StenoGraphs.@variable_as_node a)
+    # @macroexpand resolves hygiene to a GlobalRef, so compare string representation
+    @test string(expanded) == string(:(StenoGraphs.SimpleNode(:a)))
 end

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -43,7 +43,7 @@ if VERSION ≥ v"1.12-"
         # Use the re-exported macro from an "end-user" context
         # that has no direct access to StenoGraphs internals.
         result = @eval module _EndUserTest
-            using ..$(nameof(m))?: @StenoGraph, →, ←, ↔
+            using ..$(nameof(m)): @StenoGraph, →, ←, ↔
             using StenoGraphs: Node, Edge
             graph = @StenoGraph a → b
             addition = @StenoGraph a + b → c

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -7,7 +7,7 @@
             eval(:(StenoGraphs.@variable_as_node a → _(b, c)))
         catch err
         end
-    
+
         @test err isa Exception
         @test  occursin("Unqote only a single argument. Right: `_(x)`, Wrong: `_(x, y)`.", sprint(showerror, err))
     end
@@ -48,7 +48,7 @@ end
 
 
 @testset "Nested Graphs" begin
-    @test [Edge(Node(:a), Node(:b)), Edge(Node(:b), Node(:c))] == 
+    @test [Edge(Node(:a), Node(:b)), Edge(Node(:b), Node(:c))] ==
     @StenoGraph begin
         _(@StenoGraph a → b)
         b → c
@@ -57,6 +57,20 @@ end
 
 @testset "Broadcast in variable_as_node! should not turn functions into nodes" begin
     # https://github.com/aaronpeikert/StenoGraphs.jl/issues/63
-    @test StenoGraphs.variable_as_node!(:(fun.(a))) == :(fun.((SimpleNode)(:a)))
-    @test StenoGraphs.variable_as_node!(:(fun(a))) == :(fun((SimpleNode)(:a)))
+    # Function names are escaped to resolve in caller context
+    @test StenoGraphs.variable_as_node!(:(fun.(a))) == Expr(:., Expr(:escape, :fun), Expr(:tuple, :(SimpleNode(:a))))
+    @test StenoGraphs.variable_as_node!(:(fun(a))) == Expr(:call, Expr(:escape, :fun), :(SimpleNode(:a)))
+end
+
+@testset "Macro hygiene: SimpleNode resolved via Julia hygiene, not module-qualification" begin
+    # variable_as_node! produces bare SimpleNode (not StenoGraphs.SimpleNode).
+    # Julia's macro hygiene resolves it from the defining module.
+    @test StenoGraphs.variable_as_node!(:a) == Expr(:call, :SimpleNode, QuoteNode(:a))
+
+    # Function names in calls are escaped so user-defined types resolve
+    # in the caller's scope, not in StenoGraphs.
+    ex = StenoGraphs.variable_as_node!(:(MyFunc(a)))
+    @test ex.args[1] == Expr(:escape, :MyFunc)
+    @test ex.args[2] == Expr(:call, :SimpleNode, QuoteNode(:a))
+    @test @macroexpand(StenoGraphs.@variable_as_node a) == :(StenoGraphs.SimpleNode(:a))
 end


### PR DESCRIPTION
one problem I have been struggling with is balancing scoping/hygiene with quick typing and automation.

The original approach was to quote every symbol that was not a function call or operator, give users a way to escapethis quoting and evaluation in the users scope (@StenoGraph a → _(b), where a becomes Node(:a) a b exists outside already).

Then I thought it would be cool to not have the quoting because it makes some advanced automation basically impossible (like for loops) with `@declare_nodes` `@declare_nodes_from` but this pollutes/overwrites variabels in the user scope. So now we have let:

```
external = [Node(:y), Node(:z)]
@StenoGraph let a, b, c
    a → b
    c → external
end
```

and let as a splat version:

```
splat = [Node(:a), Node(:b)]
external = [Node(:y), Node(:z)]
@StenoGraph let splat..., c
    a → b
    c → external
end
```
